### PR TITLE
feat(filter): add per-column filter callback for column-specific matching logic

### DIFF
--- a/src/components/composables/useFiltering.ts
+++ b/src/components/composables/useFiltering.ts
@@ -48,6 +48,7 @@ export function useFiltering(options: IUseFilteringOptions) {
                 maxWidth: col.maxWidth,
                 headerClass: col.headerClass,
                 cellClass: col.cellClass,
+                filterCallback: col.filterCallback,
                 isUnique: col.isUnique ?? false,
                 html: col.html ?? false,
                 cellRenderer: col.cellRenderer,

--- a/src/components/filter-strategies.ts
+++ b/src/components/filter-strategies.ts
@@ -81,6 +81,7 @@ export interface INormalizedColumn {
     isUnique?: boolean;
     html?: boolean;
     cellRenderer?: ((row: Record<string, unknown>) => string) | string;
+    filterCallback?: (cellValue: unknown, row: Record<string, unknown>, search: string) => boolean;
 }
 
 /**
@@ -111,6 +112,16 @@ export const applyColumnFilters = (rows: Array<Record<string, unknown>>, columns
             continue;
         }
 
+        // If a per-column filterCallback is provided, use it to filter rows when a filter value exists
+        if (typeof col.filterCallback === 'function' && hasValue) {
+            try {
+                result = result.filter((row) => col.filterCallback!(cellValue(row, col.field), row, String(col.value)) === true);
+            } catch (err) {
+                result = result.filter(() => false);
+            }
+            continue;
+        }
+
         // Lookup type-specific strategy
         const typeFns = strategies[col.type];
         const fn = typeFns?.[col.condition];
@@ -133,11 +144,23 @@ export const applyGlobalSearch = (rows: Array<Record<string, unknown>>, columns:
     const searchableFields = columns.filter((c) => c.search && !c.hide).map((c) => c.field);
 
     return rows.filter((row) =>
-        searchableFields.some((field) =>
-            String(cellValue(row, field) ?? '')
-                .toLowerCase()
-                .includes(searchLower),
-        ),
+        searchableFields.some((field) => {
+            const raw = cellValue(row, field);
+
+            // Prefer a per-column filterCallback when available for this field
+            const col = columns.find((c) => c.field === field);
+            if (col && typeof col.filterCallback === 'function') {
+                try {
+                    return col.filterCallback(raw, row, search) === true;
+                } catch {
+                    return false;
+                }
+            }
+
+            // Default to case-insensitive substring matching
+            const text = String(raw ?? '');
+            return text.toLowerCase().includes(searchLower);
+        }),
     );
 };
 

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -162,6 +162,11 @@ export interface IColumnDefinition {
 
     /** CSS class(es) applied to each `<td>` body cell in this column. */
     cellClass?: string;
+    /**
+     * Optional per-column filter callback used for global search and filters.
+     * Signature: `(cellValue, row, value) => boolean`. Return `true` to match.
+     */
+    filterCallback?: (cellValue: unknown, row: Record<string, unknown>, search: string) => boolean;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Hello, 
I was wondering if it was possible to add specific column filter logic.

I have the following problem :

I have a column containing ISO date values. For better user experience, I use a template to display these dates in a more readable format (e.g. “10 days ago” instead of the raw ISO date).

While sorting works correctly using the original ISO values, the filtering logic only applies to the raw data. As a result, searching for terms like “10 days ago” does not return any matches, since the filter does not consider the rendered (displayed) values.

So I added a `filterCallBack` method to the columns definition to be able to apply specific column filter logic.

So I'd really appreciate if you could integrate my changes.
Thank you!